### PR TITLE
Add email templates for account verification and password reset

### DIFF
--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -1,0 +1,135 @@
+{% load i18n %}
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>{{ site.name }} {% trans "registration" %}</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .email-container {
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+        }
+
+        .header {
+            background-color: #ffd343;
+            padding: 20px;
+            text-align: center;
+        }
+
+        .logo {
+            max-width: 200px;
+            height: auto;
+        }
+
+        .content {
+            padding: 25px;
+            background-color: #ffffff;
+        }
+
+        .button-container {
+            text-align: center;
+            margin: 30px 0;
+        }
+
+        .verification-button {
+            background-color: #3776ab;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: bold;
+            display: inline-block;
+            border: none;
+            font-size: 16px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        .verification-button:hover {
+            background-color: #2d5f8b;
+        }
+
+        .verification-link {
+            margin-top: 15px;
+            word-break: break-all;
+            font-size: 14px;
+            color: #666;
+        }
+
+        .footer {
+            background-color: #f7f7f7;
+            padding: 15px;
+            text-align: center;
+            font-size: 14px;
+            color: #777;
+        }
+
+        .divider {
+            border-top: 1px solid #eeeeee;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+
+<body>
+<div class="email-container">
+    <div class="header">
+        <img src="https://za.pycon.org/static/img/header-logo-w-2025.png" alt="PyCon (ZA) Africa Logo" class="logo">
+    </div>
+    <div class="content">
+        <h2>{% trans "Verify Your Email Address" %}</h2>
+
+        <p>{% trans "Hello," %}</p>
+
+        <p>
+            {% blocktrans with site_domain=site.domain %}
+                You (or someone pretending to be you) have asked to register an account at
+                <strong>{{ site_domain }}</strong>.
+                If this wasn't you, please ignore this email and your address will be removed from our records.
+            {% endblocktrans %}
+        </p>
+
+        <div class="button-container">
+            <a href="{{ protocol }}://{{ site.domain }}{% url 'registration_activate' activation_key %}"
+               class="verification-button">{% trans "Verify Email Address" %}</a>
+        </div>
+
+        <p class="verification-link">
+            {% trans "If the button above doesn't work, please copy and paste the following link into your browser:" %}
+        </p>
+        <p class="verification-link">
+            {{ protocol }}://{{ site.domain }}{% url 'registration_activate' activation_key %}
+        </p>
+
+        <div class="divider"></div>
+
+        <p>
+            {% blocktrans with expiration_days=expiration_days %}
+                This verification link will expire in {{ expiration_days }} days.
+            {% endblocktrans %}
+        </p>
+
+        <p>
+            {% blocktrans with site_domain=site.domain %}
+                Sincerely,<br> {{ site_domain }} Management
+            {% endblocktrans %}
+        </p>
+    </div>
+    <div class="footer">
+        <p>© {% now "Y" %} PyCon Africa. {% trans "All rights reserved." %}</p>
+    </div>
+</div>
+</body>
+
+</html>

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,0 +1,124 @@
+{% load i18n %}
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% trans "PyCon Africa Password Reset" %}</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .email-container {
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+        }
+
+        .header {
+            background-color: #ffd343;
+            padding: 20px;
+            text-align: center;
+        }
+
+        .logo {
+            max-width: 200px;
+            height: auto;
+        }
+
+        .content {
+            padding: 25px;
+            background-color: #ffffff;
+        }
+
+        .button-container {
+            text-align: center;
+            margin: 30px 0;
+        }
+
+        .reset-button {
+            background-color: #3776ab;
+            color: white;
+            padding: 12px 24px;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: bold;
+            display: inline-block;
+            border: none;
+            font-size: 16px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        .reset-button:hover {
+            background-color: #2d5f8b;
+        }
+
+        .reset-link {
+            margin-top: 15px;
+            word-break: break-all;
+            font-size: 14px;
+            color: #666;
+        }
+
+        .footer {
+            background-color: #f7f7f7;
+            padding: 15px;
+            text-align: center;
+            font-size: 14px;
+            color: #777;
+        }
+
+        .divider {
+            border-top: 1px solid #eeeeee;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <img src="https://za.pycon.org/static/img/header-logo-w-2025.png" alt="PyCon Africa Logo" class="logo">
+    </div>
+    <div class="content">
+        <h2>{% trans "Reset Your Password" %}</h2>
+
+        <p>{% blocktrans %}Greetings{% endblocktrans %}
+            {% if user.get_full_name %}{{ user.get_full_name }}{% else %}{{ user }}{% endif %},</p>
+
+        <p>{% blocktrans %}
+            You are receiving this email because you (or someone pretending to be you)
+            requested that your password be reset on the {{ domain }} site. If you do not
+            wish to reset your password, please ignore this message.
+        {% endblocktrans %}</p>
+
+        <div class="button-container">
+            <a href="{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}"
+               class="reset-button">{% trans "Reset Password" %}</a>
+        </div>
+
+        <p class="reset-link">{% blocktrans %}
+            If the button above doesn't work, please copy and paste the following link
+            into your web browser:
+        {% endblocktrans %}</p>
+        <p class="reset-link">{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token }}</p>
+
+        <div class="divider"></div>
+
+        <p>{% blocktrans %}Your username, in case you've forgotten:{% endblocktrans %} {{ user.get_username }}</p>
+
+        <p>{% blocktrans %}Best regards{% endblocktrans %},<br>{{ site_name }} {% blocktrans %}
+            Management{% endblocktrans %}</p>
+    </div>
+    <div class="footer">
+        <p>© {% now "Y" %} {% trans "PyCon Africa. All rights reserved." %}</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
We currently have this view and the email was tested with the filebase email client.

![image](https://github.com/user-attachments/assets/0140fd96-3656-46be-8df9-556d4c951ea6)