### PR TITLE
FIX: update download link for full prospectus in sponsorship packages

### DIFF
--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -120,7 +120,7 @@
 
       <div class="mx-auto w-fit pt-5">
 
-         <a href="https://drive.google.com/file/d/1u0ZkJsvUHSoEzuZHLikffUlOrsNGI-Mk/view" target="_blank"
+         <a href="https://drive.google.com/file/d/1CuFVg6sk7IDENoA8HKOMRGeuRHlXLOGo/view" target="_blank"
             class="btn btn-primary">Download Full Prospectus</a>
       </div>
    </div>


### PR DESCRIPTION
Updated the download link for the full prospectus in the sponsorship packages section to ensure correct and up-to-date access to the documents.