### PR TITLE
Unify links to the prospectus

### DIFF
--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -47,7 +47,7 @@
       </div>
       <div class="mx-auto w-fit py-5">
 
-         <a href="https://drive.google.com/file/d/1u0ZkJsvUHSoEzuZHLikffUlOrsNGI-Mk/view" target="_blank"
+         <a href="https://drive.google.com/file/d/1CuFVg6sk7IDENoA8HKOMRGeuRHlXLOGo/view" target="_blank"
             class="btn btn-primary">Download Full Prospectus</a>
       </div>
 


### PR DESCRIPTION
We bave two "Download Full Prospectus" (at the top and bottom of the page). They should point at the same thing.