### PR TITLE
fix: missing icon for fediverse

### DIFF
--- a/templates/wafer.talks/snippets/social_links.html
+++ b/templates/wafer.talks/snippets/social_links.html
@@ -17,6 +17,8 @@
                         <i class="fa-brands fa-gitlab"></i>
                     {% elif social.key == 'bitbucket' %}
                         <i class="fa-brands fa-bitbucket"></i>
+                    {% elif social.key == 'fediverse' %}
+                        <i class="fa-brands fa-mastodon"></i>
                     {% elif social.key == 'other' %}
                         <i class="fa-solid fa-globe"></i>
                     {% endif %}


### PR DESCRIPTION
- fix for `fediverse` icon on socials link
<img width="244" height="85" alt="Screenshot From 2025-09-13 10-45-38" src="https://github.com/user-attachments/assets/014be1db-9b21-4f75-9700-10d00d211e65" />
